### PR TITLE
Add rotating banana bullets

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,16 @@ function handleKeyDown(e) {
     keys[e.code] = true;
     if (e.code === 'Space') {
         // throw a banana toward the enemies
-        bullets.push({ x: playerX + playerWidth/2 - 2, y: playerY, width:4, height:10, speed:7 });
+        const size = 2;
+        bullets.push({
+            x: playerX + playerWidth/2 - (5 * size)/2,
+            y: playerY,
+            width: 5 * size,
+            height: 4 * size,
+            speed: 7,
+            rotation: 0,
+            size
+        });
     }
 }
 function handleKeyUp(e) {
@@ -61,6 +70,7 @@ function update() {
     }
     for (let i = bullets.length-1; i>=0; i--) {
         bullets[i].y -= bullets[i].speed;
+        bullets[i].rotation += 0.2;
         if (bullets[i].y + bullets[i].height < 0) {
             bullets.splice(i,1);
         }
@@ -121,13 +131,35 @@ function drawGorilla(x, y, frame) {
     ctx.fillRect(x + 8, y + playerHeight, 6, 10);
     ctx.fillRect(x + playerWidth - 14, y + playerHeight, 6, 10);
 }
+
+function drawBanana(ctx, b) {
+    const pattern = [
+        [0,1,1,0,0],
+        [1,1,1,1,0],
+        [1,1,1,1,1],
+        [0,1,1,0,0]
+    ];
+    ctx.save();
+    ctx.translate(b.x + b.width/2, b.y + b.height/2);
+    ctx.rotate(b.rotation);
+    ctx.translate(-b.width/2, -b.height/2);
+    ctx.fillStyle = '#ff0';
+    const px = b.size;
+    for (let y=0; y<pattern.length; y++) {
+        for (let x=0; x<pattern[y].length; x++) {
+            if (pattern[y][x]) {
+                ctx.fillRect(x*px, y*px, px, px);
+            }
+        }
+    }
+    ctx.restore();
+}
 function draw() {
     ctx.clearRect(0,0,canvas.width, canvas.height);
     drawGorilla(playerX, playerY, animationFrame);
 
-    ctx.fillStyle = '#ff0';
     for (const b of bullets) {
-        ctx.fillRect(b.x, b.y, b.width, b.height);
+        drawBanana(ctx, b);
     }
     ctx.fillStyle = '#f60'; // orangutan enemies
     for (const e of enemies) {


### PR DESCRIPTION
## Summary
- update bullet objects with rotation and size
- spin bullets while moving upward
- draw bananas using a new `drawBanana` function
- render bananas instead of rectangles

## Testing
- `npm test` *(fails: Could not read package.json)*